### PR TITLE
Fix/deadlock on close

### DIFF
--- a/Cryptobox/Cryptobox.xcodeproj/project.pbxproj
+++ b/Cryptobox/Cryptobox.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0928E3581BA08E3D0057232E /* CBPreKey.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7EF9C11B71136600204A8E /* CBPreKey.m */; };
 		0928E3591BA08E3D0057232E /* CBSessionMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = BA74487C1B7A7F75002D9941 /* CBSessionMessage.m */; };
 		0928E36D1BA0908F0057232E /* Cryptobox.h in Headers */ = {isa = PBXBuildFile; fileRef = 0928E36C1BA0908F0057232E /* Cryptobox.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09E393C31BAC2E5600F3EA1B /* Cryptobox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0928E2341BA0777A0057232E /* Cryptobox.framework */; };
 		BA025F981B79F62A00139D15 /* CBCryptoBoxInitTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BA025F971B79F62A00139D15 /* CBCryptoBoxInitTest.m */; };
 		BA7583EE1B7B82030048FD6A /* CBCryptoBoxTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA7583ED1B7B82030048FD6A /* CBCryptoBoxTests.m */; };
 		BADF92111B80C35300766380 /* CBBasicCryptoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BADF92101B80C35300766380 /* CBBasicCryptoTest.m */; };
@@ -151,6 +152,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09E393C31BAC2E5600F3EA1B /* Cryptobox.framework in Frameworks */,
 				F503032C1B8CFA2C0053E406 /* libsodium.a in Frameworks */,
 				F503032B1B8CFA2C0053E406 /* libcryptobox.a in Frameworks */,
 			);

--- a/Cryptobox/Cryptobox/CBCryptoBox.m
+++ b/Cryptobox/Cryptobox/CBCryptoBox.m
@@ -278,18 +278,21 @@ const NSUInteger CBMaxPreKeyID = 0xFFFE;
 
 - (BOOL)close:(NSError *__nullable * __nullable)error
 {
-    __block BOOL success = YES;
+    __block BOOL success = NO;
     dispatch_sync(self.cryptoBoxQueue, ^{
         if ([self isClosedInternally]) {
+            success = YES;
             return;
         }
-        if (! [self closeAllSessions:error]) {
-            success = NO;
-            return;
-        }
-        [self closeInternally];
     });
-    return success;
+    if(success) {
+        return success;
+    }
+    if (! [self closeAllSessions:error]) {
+        return NO;
+    }
+    [self closeInternally];
+    return YES;
 }
 
 - (BOOL)isClosed

--- a/Cryptobox/CryptoboxTests/CBCryptoBoxInitTest.m
+++ b/Cryptobox/CryptoboxTests/CBCryptoBoxInitTest.m
@@ -6,9 +6,10 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
-#import "Cryptobox.h"
 #import "CBTestCase.h"
 
+
+@import Cryptobox;
 
 
 /// Very simple box init test
@@ -20,7 +21,7 @@
 
 - (void)testThatCryptoBoxInitWithPathWorks
 {
-    NSURL *directory = CBCreateTemporaryDirectoryAndReturnURL();
+    NSURL *directory = CBCreateTemporaryDirectoryAndReturnURL(self.name);
     NSError *error = nil;
     CBCryptoBox *box = [CBCryptoBox cryptoBoxWithPathURL:directory error:&error];
     XCTAssertNil(error);

--- a/Cryptobox/CryptoboxTests/CBCryptoBoxTests.m
+++ b/Cryptobox/CryptoboxTests/CBCryptoBoxTests.m
@@ -28,6 +28,9 @@
 
 - (void)tearDown
 {
+    NSError *error;
+    [self.box close:&error];
+    XCTAssertNil(error, "Error in teardown: %@", error);
     [super tearDown];
 }
 
@@ -83,6 +86,17 @@
     CBPreKey *preKey = [self.box lastPreKey:&error];
     XCTAssertNil(error);
     XCTAssertNotNil(preKey);
+}
+
+- (void)testThatItCanBeClosedMultipleTimes
+{
+    NSError *error;
+    [self.box close:&error];
+    XCTAssertNil(error, "Error in closing: %@", error);
+    [self.box close:nil];
+    XCTAssertNil(error, "Error in closing: %@", error);
+    [self.box close:nil];
+    XCTAssertNil(error, "Error in closing: %@", error);
 }
 
 @end

--- a/Cryptobox/CryptoboxTests/CBCryptoBoxTests.m
+++ b/Cryptobox/CryptoboxTests/CBCryptoBoxTests.m
@@ -6,8 +6,9 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "Cryptobox.h"
 #import "CBTestCase.h"
+
+@import Cryptobox;
 
 @interface CBCryptoBoxTests : CBTestCase
 
@@ -21,7 +22,7 @@
 {
     [super setUp];
     
-    NSURL *directory = CBCreateTemporaryDirectoryAndReturnURL();
+    NSURL *directory = CBCreateTemporaryDirectoryAndReturnURL(self.name);
     self.box = [CBCryptoBox cryptoBoxWithPathURL:directory error:nil];
 }
 

--- a/Cryptobox/CryptoboxTests/CBLastPreKeyTest.m
+++ b/Cryptobox/CryptoboxTests/CBLastPreKeyTest.m
@@ -60,8 +60,6 @@
     XCTAssertNotNil(bobSessionMessage);
     decrypted = [[NSString alloc] initWithData:bobSessionMessage.data encoding:NSUTF8StringEncoding];
     XCTAssertTrue([plain isEqualToString:decrypted]);
-    
-    NSLog(@"%s test_last_prekey finished", __PRETTY_FUNCTION__);
 }
 
 @end

--- a/Cryptobox/CryptoboxTests/CBLastPreKeyTest.m
+++ b/Cryptobox/CryptoboxTests/CBLastPreKeyTest.m
@@ -18,8 +18,8 @@
 
 - (void)testThatLastPrekeyTestCanRun
 {
-    CBCryptoBox *aliceBox = [self createBoxAndCheckAsserts];
-    CBCryptoBox *bobBox = [self createBoxAndCheckAsserts];
+    CBCryptoBox *aliceBox = [self createBoxAndCheckAsserts:@"alice"];
+    CBCryptoBox *bobBox = [self createBoxAndCheckAsserts:@"bob"];
 
     NSError *error = nil;
     CBPreKey *bobLastPreKey = [bobBox lastPreKey:&error];

--- a/Cryptobox/CryptoboxTests/CBPreKeyRemovalTest.m
+++ b/Cryptobox/CryptoboxTests/CBPreKeyRemovalTest.m
@@ -20,8 +20,8 @@
 
 - (void)testExample
 {
-    CBCryptoBox *aliceBox = [self createBoxAndCheckAsserts];
-    CBCryptoBox *bobBox = [self createBoxAndCheckAsserts];
+    CBCryptoBox *aliceBox = [self createBoxAndCheckAsserts:@"alice"];
+    CBCryptoBox *bobBox = [self createBoxAndCheckAsserts:@"bob"];
     
     
     CBPreKey *bobPreKey = [self generatePreKeyAndCheckAssertsWithLocation:1 box:bobBox];

--- a/Cryptobox/CryptoboxTests/CBTestCase.h
+++ b/Cryptobox/CryptoboxTests/CBTestCase.h
@@ -10,13 +10,13 @@
 
 
 
-FOUNDATION_EXPORT NSURL *__nullable CBCreateTemporaryDirectoryAndReturnURL();
+FOUNDATION_EXPORT NSURL *__nullable CBCreateTemporaryDirectoryAndReturnURL(NSString * __nonnull name);
 
 
 
 @interface CBTestCase : XCTestCase
 
-- (nullable CBCryptoBox *)createBoxAndCheckAsserts;
+- (nullable CBCryptoBox *)createBoxAndCheckAsserts:(NSString * __nonnull)userName;
 
 - (nullable NSArray *)generatePreKeysAndCheckAssertsWithRange:(NSRange)range box:(nonnull CBCryptoBox *)box;
 

--- a/Cryptobox/CryptoboxTests/CBTestCase.m
+++ b/Cryptobox/CryptoboxTests/CBTestCase.m
@@ -7,12 +7,12 @@
 
 #import "Cryptobox.h"
 
-NSURL *__nullable CBCreateTemporaryDirectoryAndReturnURL(void);
+NSURL *__nullable CBCreateTemporaryDirectoryAndReturnURL(NSString *name);
 
-NSURL *__nullable CBCreateTemporaryDirectoryAndReturnURL(void)
+NSURL *__nullable CBCreateTemporaryDirectoryAndReturnURL(NSString *name)
 {
     NSError *error = nil;
-    NSURL *directoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]] isDirectory:YES];
+    NSURL *directoryURL = [NSURL fileURLWithPath:[[NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]] stringByAppendingPathComponent:name] isDirectory:YES];
     [[NSFileManager defaultManager] createDirectoryAtURL:directoryURL withIntermediateDirectories:YES attributes:nil error:&error];
     if (error) {
         return nil;
@@ -25,9 +25,9 @@ NSURL *__nullable CBCreateTemporaryDirectoryAndReturnURL(void)
 
 @implementation CBTestCase
 
-- (CBCryptoBox *)createBoxAndCheckAsserts
+- (nullable CBCryptoBox *)createBoxAndCheckAsserts:(NSString *__nonnull)userName
 {
-    NSURL *url = CBCreateTemporaryDirectoryAndReturnURL();
+    NSURL *url = CBCreateTemporaryDirectoryAndReturnURL(userName);
     NSError *error = nil;
     CBCryptoBox *box = [CBCryptoBox cryptoBoxWithPathURL:url error:&error];
     XCTAssertNil(error, @"");


### PR DESCRIPTION
Remove deadlock on `CBCryptoBox close` caused by re-entrant `dyspatch_sync`.

As a comment, I would also argue that the current synchronization mechanism could be removed. Basically every call is wrapped in a `dyspatch_sync`, which is not better than documenting CBCryptoBox as not thread-safe and leaving the synchronization (if needed!) to the user.